### PR TITLE
Add safety check for jQuery in paste_form

### DIFF
--- a/paste_form.js
+++ b/paste_form.js
@@ -9,6 +9,10 @@ if (typeof jQuery === 'undefined' || typeof $ === 'undefined') {
     // or inject your own copy.
     console.error("jQuery is not defined in content script's isolated world. Trying to inject or wait.");
 
+    // Without jQuery available there's no point in executing the rest of the
+    // script. Return early so we don't hit runtime errors later on.
+    return;
+
     // Option A: Try to get jQuery from the page's window object.
     // This is often the best approach for content scripts that interact with existing page elements.
     // However, it relies on 'window.jQuery' being exposed by the page's script.


### PR DESCRIPTION
## Summary
- stop executing `paste_form.js` when jQuery isn't loaded

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a197cf9e48324ba41346b92613249